### PR TITLE
Fixed css that broke during conflict resolution

### DIFF
--- a/schedules/app/assets/stylesheets/application.scss
+++ b/schedules/app/assets/stylesheets/application.scss
@@ -287,6 +287,15 @@ footer {
     padding: 0px;
 }
 
+
+
+li:target{
+    background-color: #cfc;
+    *{
+        background-color: #cfc !important;
+    }
+}
+
 @media only screen and (min-width: 600px) {
     .cart {
         bottom: inherit;
@@ -396,8 +405,11 @@ footer {
             color: $green;
         }
     }*/
-
-    :target{
-        background-color: $lightgreen;
+    li:target{
+        background-color: #131;
+        *{
+            background-color: #131 !important;
+        }
     }
+
 }


### PR DESCRIPTION
Due to an issue with updating my local files, the course selection highlighting was only enabled in dark mode. Along with also enabling it in light mode, I took the chance to improve the CSS.