### PR TITLE
Resolved issue 29

### DIFF
--- a/schedules/app/controllers/search_controller.rb
+++ b/schedules/app/controllers/search_controller.rb
@@ -33,8 +33,10 @@ class SearchController < ApplicationController
 
     /[0-9]{5}/.match(params[:query]) do |m|
       course = CourseSection.latest_by_crn(m[0])
-      url = course_url(course.course) + "#section-" + course.id.to_s
-      redirect_to(url)
+      if not course.nil?
+        url = course_url(course.course) + "#section-" + course.id.to_s
+      end
+      redirect_to(url) unless course.nil?
     end
 
     if @courses&.count == 1 && @instructors&.count&.zero?

--- a/schedules/app/controllers/search_controller.rb
+++ b/schedules/app/controllers/search_controller.rb
@@ -33,10 +33,10 @@ class SearchController < ApplicationController
 
     /[0-9]{5}/.match(params[:query]) do |m|
       course = CourseSection.latest_by_crn(m[0])
-      if not course.nil?
+      unless course.nil?
         url = course_url(course.course) + "#section-" + course.id.to_s
+        redirect_to(url)
       end
-      redirect_to(url) unless course.nil?
     end
 
     if @courses&.count == 1 && @instructors&.count&.zero?

--- a/schedules/app/views/search/index.html.erb
+++ b/schedules/app/views/search/index.html.erb
@@ -17,7 +17,7 @@
     </section>
   <% end %>
 
-  <% if @courses&.empty? && @instructors&.empty? %>
+  <% if (@courses&.empty? || @courses.nil?) && (@instructors&.empty? || @instructors.nil?) %>
     <span>No results found. Please try again with another search term.</span>
   <% end %>
 </div>


### PR DESCRIPTION
Resolved #29 by only redirecting to the course page when a course with the specified CRN is found.

When a CRN is entered in the search, search_controller.rb used to ALWAYS send the user to the page for that course. If no course existed with that CRN, it would cause an error, as that page doesn't exist. The new behaviour only redirects to the course page when a course is actually found, otherwise it stays on the query page.

Additionally, the query page did not display a "No Results Found" message when the courses and instructors found were nil values, as it was previously impossible to reach that site with those variables holding nil values. But with the above fix, that is now possible, so now it checks to see if the courses or instructors are empty OR nil, and if they both are, it displays the "No results found" message.